### PR TITLE
chore: fix Swift interface branch names

### DIFF
--- a/.github/workflows/generate-swiftinterface.yml
+++ b/.github/workflows/generate-swiftinterface.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           target_branch="${INPUT_TARGET_BRANCH:-$GITHUB_REF_NAME}"
-          interface_branch="automation/swiftinterfaces/$GITHUB_RUN_ID/$PLATFORM"
+          interface_branch="automation/swiftinterfaces-$GITHUB_RUN_ID-$PLATFORM"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C "$interface_branch"

--- a/.github/workflows/update-swiftinterfaces.yml
+++ b/.github/workflows/update-swiftinterfaces.yml
@@ -30,7 +30,7 @@ jobs:
         id: branch
         shell: bash
         run: |
-          update_branch="automation/swiftinterfaces/$GITHUB_RUN_ID"
+          update_branch="automation/swiftinterfaces-$GITHUB_RUN_ID"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C "$update_branch"


### PR DESCRIPTION
## Summary

- name the aggregation branch `automation/swiftinterfaces-<run-id>`
- name platform branches `automation/swiftinterfaces-<run-id>-<platform>`

## Root cause

The previous aggregation branch was `automation/swiftinterfaces/<run-id>`, while platform jobs attempted to create branches below that ref as `automation/swiftinterfaces/<run-id>/<platform>`. Git cannot store a branch and child branches beneath the same ref, so every platform job failed before interface generation began.

## Validation

- verified the updated branch templates exactly match the intended names
- checked the workflow diff with `git diff --check`
